### PR TITLE
Fix bottom white gap visible on mobile view

### DIFF
--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -37,7 +37,7 @@ const Layout = ({ children }) => {
   }, [location]);
 
   return (
-    <Box sx={{ display: "flex" }}>
+    <Box sx={{ display: "flex", overflowY: "hidden" }}>
       <Menu
         open={open}
         handleDrawerClose={handleDrawerClose}


### PR DESCRIPTION
The white gap visible on mobile view is because of an overflow from Layout.js. By adding overflowY: "hidden", the white gap has disappeared on mobile view.