### PR TITLE
fix: closed date column shows correctly

### DIFF
--- a/src/store/TransfersContext.js
+++ b/src/store/TransfersContext.js
@@ -123,7 +123,7 @@ const TransfersProvider = ({ children }) => {
         receiver_wallet: row.destination_wallet,
         created_date: row.created_at,
         initiated_by: row.originating_wallet,
-        closed_date: row.cloased_at,
+        closed_date: row.closed_at,
         status: row.state,
       };
     });


### PR DESCRIPTION
Simple fix, Closed Date column now displays information correctly.

![image](https://github.com/Greenstand/treetracker-wallet-admin-client/assets/15161954/7191b5b3-99f9-4ca4-8556-9622904dd6de)
