### PR TITLE
Reset filters button

### DIFF
--- a/src/pages/MyTransfers/MyTransfers.js
+++ b/src/pages/MyTransfers/MyTransfers.js
@@ -54,7 +54,7 @@ const MyTransfers = () => {
       }}
     >
       {message && <Message message={message} onClose={() => setMessage('')} />}
-      <Grid container direction="column" sx={{ flexGrow: '1' }}>
+      <Grid container direction='column' sx={{ flexGrow: '1' }}>
         <TransfersTable
           tableTitle={'My Transfers'}
           tableRows={tableRows}

--- a/src/pages/MyTransfers/MyTransfers.test.js
+++ b/src/pages/MyTransfers/MyTransfers.test.js
@@ -68,6 +68,11 @@ const mockTransfersData = {
       token_count: 1,
     },
   ],
+  query: {
+    limit: 200,
+    offset: 0,
+  },
+  total: 3,
 };
 
 const TestWrapper = (props) => {
@@ -82,14 +87,14 @@ const TestWrapper = (props) => {
   );
 };
 
-describe('My Transfers page', function () {
+describe('My Transfers page', function() {
   beforeEach(() => {
     localStorage.setItem(
       'wallet',
       JSON.stringify({
         id: '9d6c674f-ae62-4fab-8d14-ae5de9f14ab8',
         wallet: 'test wallet',
-      })
+      }),
     );
   });
 
@@ -103,18 +108,18 @@ describe('My Transfers page', function () {
     render(
       <TestWrapper>
         <MyTransfers />
-      </TestWrapper>
+      </TestWrapper>,
     );
 
     expect(await screen.findByTestId('table-pagination')).toBeInTheDocument();
     expect(await screen.findByTestId('transfers-table')).toBeInTheDocument();
     expect(await screen.findByTestId('date-range-filter')).toBeInTheDocument();
     expect(
-      await screen.findByTestId('transfer-status-filter')
+      await screen.findByTestId('transfer-status-filter'),
     ).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getAllByRole('row')).toHaveLength(3 + 1);
+      expect(screen.getAllByRole('row')).toHaveLength(mockTransfersData.total + 1);
     });
   });
 });

--- a/src/pages/MyTransfers/TableFilters.js
+++ b/src/pages/MyTransfers/TableFilters.js
@@ -15,26 +15,27 @@ import {
   SelectFilter,
   SelectMenuItem,
   DateRangeButton,
-  DateRangeFilterIcon,
+  DateRangeFilterIcon, FilterResetButton,
 } from './TableFilters.styled';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { DatePicker, DateRangeIcon } from '@mui/x-date-pickers';
 import { getDateText } from '../../utils/formatting';
-import { useTransfersContext } from '../../store/TransfersContext';
 import TransferFilter from '../../models/TransferFilter';
 
 /**@function
  * @name TransferFilter
  * @description Renders the transfer status filter
  *
+ * @param filter
+ * @param setFilter
+ * @param statusList
  * @param {function} getStatusColor returns color corresponding to transfer state value
  *
  * @return {JSX.Element} Transfer status filter component
  * @constructor
  */
-export const TransferSelectFilter = ({ getStatusColor }) => {
-  // get filter from context
-  const { filter, setFilter, statusList } = useTransfersContext();
+export const TransferSelectFilter = ({ filter, setFilter, statusList, getStatusColor }) => {
+  // get state from filter
   const { state } = filter;
 
   const handleSelectChange = (e) => {
@@ -80,14 +81,16 @@ export const TransferSelectFilter = ({ getStatusColor }) => {
  * @return {JSX.Element} Date range filter component
  * @constructor
  */
-export const DateRangeFilter = () => {
-  // get filter from context
-  const { filter, setFilter } = useTransfersContext();
+export const DateRangeFilter = ({ filter, setFilter }) => {
+
+  // start and end dates (from filter)
+  const { after, before } = filter;
 
   // start and end dates (for datepicker display)
   // they are dayjs date objects
-  const [startDate, setStartDate] = useState(null);
-  const [endDate, setEndDate] = useState(null);
+  // set as after and before in case there is default value
+  const [startDate, setStartDate] = useState(after);
+  const [endDate, setEndDate] = useState(before);
 
   // disable OK button on either datepicker error
   const [isStartDateError, setIsStartDateError] = useState(false);
@@ -98,6 +101,12 @@ export const DateRangeFilter = () => {
   // MM/DD/YYYY format is used to convert date object to text
   const dateFormat = defaultDateText.toUpperCase();
 
+  // update start and end dates when filter reset button is clicked
+  useEffect(() => {
+    setStartDate(after);
+    setEndDate(before);
+  }, [after, before]);
+
   // opens the popover
   const handleClick = (e) => {
     setAnchorEl(e.target);
@@ -105,12 +114,12 @@ export const DateRangeFilter = () => {
 
   // resets dates to previously present values and closes the popover
   const handleClose = () => {
-    setStartDate(startDate);
-    setEndDate(endDate);
+    setStartDate(after);
+    setEndDate(before);
     setAnchorEl(null);
   };
 
-  // updates the filter object and closes the popver
+  // updates the filter object and closes the popover
   const handleOK = () => {
     const newFilter = new TransferFilter({
       ...filter,
@@ -189,5 +198,19 @@ export const DateRangeFilter = () => {
         </Card>
       </Popover>
     </FormControl>
+  );
+};
+
+
+export const ResetButton = ({ setFilter, defaultFilter }) => {
+  return (
+    <FilterResetButton
+      onClick={() => setFilter(defaultFilter)}
+      type='submit'
+      variant='contained'
+      color='primary'
+    >
+      Reset
+    </FilterResetButton>
   );
 };

--- a/src/pages/MyTransfers/TableFilters.js
+++ b/src/pages/MyTransfers/TableFilters.js
@@ -43,7 +43,7 @@ export const TransferSelectFilter = ({ getStatusColor }) => {
   };
 
   return (
-    <FormControl sx={{ width: '192px' }} data-testid="transfer-status-filter">
+    <FormControl sx={{ width: '192px' }} data-testid='transfer-status-filter'>
       <FilterLabelText>Transfer Status</FilterLabelText>
 
       <SelectFilter
@@ -105,8 +105,8 @@ export const DateRangeFilter = () => {
 
   // resets dates to previously present values and closes the popover
   const handleClose = () => {
-    setStartDate(null);
-    setEndDate(null);
+    setStartDate(startDate);
+    setEndDate(endDate);
     setAnchorEl(null);
   };
 
@@ -123,7 +123,7 @@ export const DateRangeFilter = () => {
   };
 
   return (
-    <FormControl sx={{ width: '192px' }} data-testid="date-range-filter">
+    <FormControl sx={{ width: '192px' }} data-testid='date-range-filter'>
       <FilterLabelText>Created Date</FilterLabelText>
       <DateRangeButton onClick={handleClick} endIcon={<DateRangeFilterIcon />}>
         {startDate ? getDateText(startDate, dateFormat) : defaultDateText} -{' '}

--- a/src/pages/MyTransfers/TableFilters.js
+++ b/src/pages/MyTransfers/TableFilters.js
@@ -206,7 +206,7 @@ export const ResetButton = ({ setFilter, defaultFilter }) => {
   return (
     <FilterResetButton
       onClick={() => setFilter(defaultFilter)}
-      type='submit'
+      type='button'
       variant='contained'
       color='primary'
       data-testid='reset-filters'

--- a/src/pages/MyTransfers/TableFilters.js
+++ b/src/pages/MyTransfers/TableFilters.js
@@ -209,6 +209,7 @@ export const ResetButton = ({ setFilter, defaultFilter }) => {
       type='submit'
       variant='contained'
       color='primary'
+      data-testid='reset-filters'
     >
       Reset
     </FilterResetButton>

--- a/src/pages/MyTransfers/TableFilters.styled.js
+++ b/src/pages/MyTransfers/TableFilters.styled.js
@@ -72,3 +72,9 @@ export const DateRangeButton = styled(Button)({
 export const DateRangeFilterIcon = styled(DateRangeIcon)({
   color: '#86c232',
 });
+
+export const FilterResetButton = styled(Button)({
+  color: '#fff',
+  height: '40px',
+  padding: '8px 8px 8px 10px',
+});

--- a/src/pages/MyTransfers/TableFilters.styled.js
+++ b/src/pages/MyTransfers/TableFilters.styled.js
@@ -75,6 +75,7 @@ export const DateRangeFilterIcon = styled(DateRangeIcon)({
 
 export const FilterResetButton = styled(Button)({
   color: '#fff',
-  height: '40px',
-  padding: '8px 8px 8px 10px',
+  height: '2.5rem',
+  boxShadow: 'none',
+  padding: '0.5rem 0.5rem 0.5rem 0.625rem',
 });

--- a/src/pages/MyTransfers/TableFilters.test.js
+++ b/src/pages/MyTransfers/TableFilters.test.js
@@ -120,8 +120,48 @@ describe('Transfers table header', () => {
     await screen.findByRole('dialog', { hidden: true });
   });
 
+  it('Date range filter errors work correctly', async () => {
+    render(
+      <TestWrapper>
+        <DateRangeFilter filter={mockFilter} setFilter={setMockFilter} />
+      </TestWrapper>,
+    );
+
+    const button = screen.getByRole('button');
+    userEvent.click(button);
+
+    // test typing invalid date
+    const dateTextbox = screen.getByRole('textbox', { name: 'Start date' });
+    userEvent.type(dateTextbox, '08200003');
+    expect(dateTextbox.value).toBe('08/20/0003');
+
+    expect(screen.getByText(/Invalid Date/)).toBeInTheDocument();
+
+    const okButton = screen.getByRole('button', { name: 'OK' });
+    expect(okButton).toBeDisabled();
+
+    // entering valid date re-enables the OK button
+    userEvent.type(dateTextbox, '08201998');
+    expect(okButton).toBeEnabled();
+  });
+
   it('Reset filters button renders correctly', () => {
+
+    mockFilter = {
+      state: 'Requested',
+      wallet: 'testwallet',
+      before: '1993-08-10',
+      after: '1993-08-01',
+    };
+
     render(<ResetButton setFilter={setMockFilter} defaultFilter={mockDefaultFilter} />);
 
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Reset/ })).toBeInTheDocument();
+
+    const resetButton = screen.getByRole('button');
+    userEvent.click(resetButton);
+
+    expect(mockFilter).toEqual(mockDefaultFilter);
   });
 });

--- a/src/pages/MyTransfers/TableFilters.test.js
+++ b/src/pages/MyTransfers/TableFilters.test.js
@@ -1,26 +1,51 @@
-import { TransfersProvider } from '../../store/TransfersContext';
 import { render, screen } from '@testing-library/react';
-import { DateRangeFilter, TransferSelectFilter } from './TableFilters';
+import { DateRangeFilter, ResetButton, TransferSelectFilter } from './TableFilters';
 import userEvent from '@testing-library/user-event';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
+import TransferFilter from '../../models/TransferFilter';
 
 const TestWrapper = (props) => {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <TransfersProvider>
-        {props.children}
-      </TransfersProvider>
+      {props.children}
     </LocalizationProvider>
   );
 };
 
+const mockStatusList = [{
+  label: 'Requested',
+  value: 'requested',
+  color: 'black',
+},
+  {
+    label: 'Pending',
+    value: 'pending',
+    color: 'black',
+  }];
+
+const mockDefaultFilter = new TransferFilter({
+  state: '',
+  before: null,
+  after: null,
+  wallet: null,
+});
+
+let mockFilter = mockDefaultFilter;
+const setMockFilter = (newValue) => {
+  mockFilter = newValue;
+};
+
+beforeEach(() => {
+  setMockFilter(mockDefaultFilter);
+});
+
 describe('Transfers table header', () => {
+
   it('Transfer filter renders correctly', () => {
-    render(
-      <TestWrapper>
-        <TransferSelectFilter getStatusColor={() => ''} />
-      </TestWrapper>,
+    const { rerender } = render(
+      <TransferSelectFilter filter={mockFilter} setFilter={setMockFilter} statusList={mockStatusList}
+                            getStatusColor={() => ''} />,
     );
 
     expect(screen.getByTestId('transfer-status-filter')).toBeInTheDocument();
@@ -34,22 +59,26 @@ describe('Transfers table header', () => {
 
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     expect(screen.getByRole('presentation')).toBeInTheDocument();
-    expect(screen.getAllByRole('option')).toHaveLength(6);
+    expect(screen.getAllByRole('option')).toHaveLength(3);
 
     // click an option to test select value changes
-    const option = screen.getByRole('option', { name: 'Completed' });
+    const option = screen.getByRole('option', { name: 'Pending' });
     userEvent.click(option);
+
+    // force re-render to update the select component, as we are using mocked state
+    rerender(<TransferSelectFilter filter={mockFilter} setFilter={setMockFilter} statusList={mockStatusList}
+                                   getStatusColor={() => ''} />);
 
     expect(screen.queryByRole('presentation')).toBeNull();
     expect(screen.queryByRole('listbox')).toBeNull();
     expect(screen.queryAllByRole('option')).toHaveLength(0);
-    expect(screen.getByRole('button', { name: 'Completed' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pending' })).toBeInTheDocument();
   });
 
   it('Date range filter renders correctly', async () => {
     render(
       <TestWrapper>
-        <DateRangeFilter />
+        <DateRangeFilter filter={mockFilter} setFilter={setMockFilter} />
       </TestWrapper>,
     );
 
@@ -89,5 +118,10 @@ describe('Transfers table header', () => {
 
     expect(dateTextbox.value).toBe('08/10/1993');
     await screen.findByRole('dialog', { hidden: true });
+  });
+
+  it('Reset filters button renders correctly', () => {
+    render(<ResetButton setFilter={setMockFilter} defaultFilter={mockDefaultFilter} />);
+
   });
 });

--- a/src/pages/MyTransfers/TransfersTable.js
+++ b/src/pages/MyTransfers/TransfersTable.js
@@ -11,7 +11,7 @@ import {
   Typography,
 } from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
-import { DateRangeFilter, TransferSelectFilter } from './TableFilters';
+import { DateRangeFilter, ResetButton, TransferSelectFilter } from './TableFilters';
 import { TableCellStyled, TooltipStyled } from './TransfersTable.styled';
 import { useTransfersContext } from '../../store/TransfersContext';
 import { Loader } from '../../components/UI/components/Loader/Loader';
@@ -25,17 +25,27 @@ import { Loader } from '../../components/UI/components/Loader/Loader';
  * @returns {JSX.Element} - Table header component
  */
 const TransfersTableHeader = ({ tableTitle, getStatusColor }) => {
+  const { filter, setFilter, statusList, defaultFilter } = useTransfersContext();
+  
   return (
     <Grid item container sx={{ paddingBottom: '15px' }}>
-      <Grid item xs={7} sx={{ display: 'flex', alignItems: 'end' }}>
+      <Grid item xs={4} sx={{ display: 'flex', alignItems: 'end' }}>
         <Typography variant={'h4'}>{tableTitle}</Typography>
       </Grid>
-      <Grid item container xs={5}>
-        <Grid item xs={6} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <TransferSelectFilter getStatusColor={getStatusColor} />
+      <Grid item container xs={8}>
+        <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'end' }}>
+          <ResetButton setFilter={setFilter} defaultFilter={defaultFilter} />
         </Grid>
-        <Grid item xs={6} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <DateRangeFilter />
+        <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <TransferSelectFilter
+            filter={filter}
+            setFilter={setFilter}
+            statusList={statusList}
+            getStatusColor={getStatusColor}
+          />
+        </Grid>
+        <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <DateRangeFilter filter={filter} setFilter={setFilter} />
         </Grid>
       </Grid>
     </Grid>
@@ -56,7 +66,7 @@ const OverflownCell = ({ cellValue, cellColor, children }) => {
 
   useEffect(() => {
     setIsOverflown(
-      textElementRef.current.scrollWidth > textElementRef.current.clientWidth
+      textElementRef.current.scrollWidth > textElementRef.current.clientWidth,
     );
   }, []);
 
@@ -198,8 +208,8 @@ const TransfersTable = ({ tableTitle, tableRows, totalRowCount }) => {
         <Table
           stickyHeader
           sx={{ minWidth: 650 }}
-          aria-label="transfers table"
-          data-testid="transfers-table"
+          aria-label='transfers table'
+          data-testid='transfers-table'
         >
           <TableHead>
             <TableRow>
@@ -232,7 +242,7 @@ const TransfersTable = ({ tableTitle, tableRows, totalRowCount }) => {
         onRowsPerPageChange={handleRowsPerPageChange}
         page={page}
         onPageChange={(e, newPage) => handlePageChange(e, newPage)}
-        data-testid="table-pagination"
+        data-testid='table-pagination'
       />
     </Grid>
   );

--- a/src/pages/MyTransfers/TransfersTable.js
+++ b/src/pages/MyTransfers/TransfersTable.js
@@ -26,17 +26,14 @@ import { Loader } from '../../components/UI/components/Loader/Loader';
  */
 const TransfersTableHeader = ({ tableTitle, getStatusColor }) => {
   const { filter, setFilter, statusList, defaultFilter } = useTransfersContext();
-  
+
   return (
     <Grid item container sx={{ paddingBottom: '15px' }}>
-      <Grid item xs={4} sx={{ display: 'flex', alignItems: 'end' }}>
+      <Grid item xs={6} sx={{ display: 'flex', alignItems: 'end' }}>
         <Typography variant={'h4'}>{tableTitle}</Typography>
       </Grid>
-      <Grid item container xs={8}>
-        <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'end' }}>
-          <ResetButton setFilter={setFilter} defaultFilter={defaultFilter} />
-        </Grid>
-        <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Grid item container xs={6}>
+        <Grid item xs={5} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
           <TransferSelectFilter
             filter={filter}
             setFilter={setFilter}
@@ -44,8 +41,11 @@ const TransfersTableHeader = ({ tableTitle, getStatusColor }) => {
             getStatusColor={getStatusColor}
           />
         </Grid>
-        <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Grid item xs={5} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
           <DateRangeFilter filter={filter} setFilter={setFilter} />
+        </Grid>
+        <Grid item xs={2} sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'end' }}>
+          <ResetButton setFilter={setFilter} defaultFilter={defaultFilter} />
         </Grid>
       </Grid>
     </Grid>

--- a/src/pages/MyTransfers/TransfersTable.test.js
+++ b/src/pages/MyTransfers/TransfersTable.test.js
@@ -43,7 +43,7 @@ describe('Transfers Table', () => {
       JSON.stringify({
         id: '9d6c674f-ae62-4fab-8d14-ae5de9f14ab8',
         wallet: 'test wallet',
-      })
+      }),
     );
   });
 
@@ -57,19 +57,20 @@ describe('Transfers Table', () => {
         <TransfersTable
           tableTitle={'My Transfers'}
           tableRows={mockTableRows}
-          totalRowCount={3}
+          totalRowCount={mockTableRows.length}
         />
-      </TestWrapper>
+      </TestWrapper>,
     );
 
     expect(await screen.findByTestId('table-pagination')).toBeInTheDocument();
-    https: expect(
-      await screen.findByTestId('transfers-table')
+    expect(
+      await screen.findByTestId('transfers-table'),
     ).toBeInTheDocument();
     expect(await screen.findByTestId('date-range-filter')).toBeInTheDocument();
     expect(
-      await screen.findByTestId('transfer-status-filter')
+      await screen.findByTestId('transfer-status-filter'),
     ).toBeInTheDocument();
+    expect(await screen.findByTestId('reset-filters')).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getAllByRole('row')).toHaveLength(3 + 1);
@@ -79,13 +80,13 @@ describe('Transfers Table', () => {
 
     expect(await screen.findByTestId('table-pagination')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Rows per page: 10' })
+      screen.getByRole('button', { name: /Rows per page/ }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Go to previous page' })
+      screen.getByRole('button', { name: 'Go to previous page' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Go to next page' })
+      screen.getByRole('button', { name: 'Go to next page' }),
     ).toBeInTheDocument();
   });
 });

--- a/src/store/TransfersContext.js
+++ b/src/store/TransfersContext.js
@@ -143,8 +143,6 @@ const TransfersProvider = ({ children }) => {
     prepareRows,
   };
 
-  console.log('filterss', filter);
-
   return (
     <TransfersContext.Provider value={value}>
       {children}

--- a/src/store/TransfersContext.js
+++ b/src/store/TransfersContext.js
@@ -134,6 +134,7 @@ const TransfersProvider = ({ children }) => {
     pagination,
     setPagination,
     filter,
+    defaultFilter,
     setFilter,
     statusList,
     isLoading,
@@ -141,6 +142,8 @@ const TransfersProvider = ({ children }) => {
     tableColumns,
     prepareRows,
   };
+
+  console.log('filterss', filter);
 
   return (
     <TransfersContext.Provider value={value}>


### PR DESCRIPTION
## Description
A button to reset My Transfer table filters is implemented.

**Issue(s) addressed**
- Resolves #74 

**What kind of change(s) does this PR introduce?**

- [X] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
Currently, there is no way to reset the table filters without manually changing the values.

**What is the new behavior?**
- A Reset button is added as given below:

![image](https://github.com/Greenstand/treetracker-wallet-admin-client/assets/15161954/deb40807-173d-4ef5-8664-633a676a2e74)


![Recording 2023-08-21 at 20 36 57](https://github.com/Greenstand/treetracker-wallet-admin-client/assets/15161954/9a59e790-a7bc-4f75-9ea6-514a37a69bb0)


## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.