### PR TITLE
fix context provider wrap in the layout

### DIFF
--- a/src/components/Routes/ClientRoutes.js
+++ b/src/components/Routes/ClientRoutes.js
@@ -32,9 +32,11 @@ const ClientRoutes = () => {
           path="/"
           exact
           element={
+          <TrustRelationshipsProvider>
             <Layout>
               <Wallet />
             </Layout>
+          </TrustRelationshipsProvider>
           }
         />
         <Route


### PR DESCRIPTION
This is to solve the context error, that the context should be used within context provider children