### PR TITLE
Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -94,7 +94,7 @@ jobs:
         if: github.event_name == 'push' && github.repository == ${{ env.repository }}
         run: npm run build:dev
         working-directory: ${{ env.project-directory }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: github.event_name == 'push' && github.repository == ${{ env.repository }}
         with:
           name: client-bundle

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -124,7 +124,7 @@ jobs:
         if: "contains(github.event.inputs.env, 'dev')"
         run: npm run build:dev
         working-directory: ${{ env.project-directory }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: frontend-bundle
           path: build

--- a/.github/workflows/treetracker-wallet-admin-pr.yaml
+++ b/.github/workflows/treetracker-wallet-admin-pr.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.event_name == 'push' && github.repository == 'Greenstand/treetracker-wallet-admin-client'
         run: npm run build:dev
         working-directory: ${{ env.project-directory }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: github.event_name == 'push' && github.repository == 'Greenstand/treetracker-wallet-admin-client'
         with:
           name: client-bundle


### PR DESCRIPTION
This PR upgrades the  actions/upload-artifact from v2 to v4 to fix the failing checks in github