### PR TITLE
Remove walletType dependency in useEffect for optimization

### DIFF
--- a/src/pages/SendTokens/SendTokensForm/SelectWallet.js
+++ b/src/pages/SendTokens/SendTokensForm/SelectWallet.js
@@ -74,7 +74,7 @@ function SelectWallet({
     };
 
     getWalletsData();
-  }, [walletSearchString, walletType]);
+  }, [walletSearchString]);
 
   useEffect(() => {
     // If createdWalletName is not null, get wallets again by createdWalletName and set it as selected value


### PR DESCRIPTION
### Summary
 Removed walletType dependency from useEffect to optimize wallets fetching in Selecting wallets for send tokens functionality. This is to fix endless fetching of wallets happening  in test server.