### PR TITLE
Prevent self-referencing in trusted wallets list

### DIFF
--- a/src/api/trust_relationships.js
+++ b/src/api/trust_relationships.js
@@ -131,10 +131,24 @@ export const getTrustedWallets = async (token) => {
     const response = await apiClient
       .setAuthHeader(token)
       .get(`/wallets/${wallet.id}/trust_relationships?exclude_managed=true`);
+
+      const checkLoggedInWalletId = (relationship) => {
+        if (wallet.id === relationship.target_wallet_id) {
+          return relationship.originator_wallet_id;
+        }
+        return relationship.target_wallet_id;
+      }
+      
+      const checkLoggedInWalletName = (relationship) => {
+        if (wallet.id === relationship.target_wallet_id) {
+          return relationship.originating_wallet;
+        }
+        return relationship.target_wallet;
+      }
     
     const trustedWallets = response.data.trust_relationships.map(relationship => ({
-      id: relationship.actor_wallet_id,
-      name: relationship.actor_wallet,
+      id: checkLoggedInWalletId(relationship),
+      name: checkLoggedInWalletName(relationship),
       tokensInWallet: 0, 
     }));
     


### PR DESCRIPTION
## Summary

This PR fixes an issue where the trusted wallets list could incorrectly include the logged-in wallet itself.
The fix adds helper functions that check the trust relationship against the logged-in wallet to ensure only the "other" wallet in the relationship is returned, preventing the logged-in wallet from appearing in its own trusted wallets list.


## Tasks Completed

- [x] Added `checkLoggedInWalletId` helper function to determine the correct wallet ID (the other wallet in the relationship)
- [x] Added `checkLoggedInWalletName` helper function to determine the correct wallet name
- [x] Updated `getTrustedWallets` to use the new helper functions
- [x] Ensured trusted wallets list only displays wallets that trust or are trusted by the logged-in wallet, excluding the wallet itself