### PR TITLE
refactor(Transfers): Remove unused sorting functions and streamline data preparation

### DIFF
--- a/src/store/TransfersContext.js
+++ b/src/store/TransfersContext.js
@@ -158,34 +158,6 @@ const TransfersProvider = ({ children }) => {
     });
   };
 
-  const getStatusPriority = (status) => {
-    switch (status) {
-      case 'pending':
-        return 1;
-      case 'completed':
-        return 2;
-      case 'cancelled':
-        return 3;
-      default:
-        return 4;
-    }
-  };
-
-  const sortRowsByDefaultOrder = (rows) => {
-    return [...rows].sort((a, b) => {
-      const statusPriorityA = getStatusPriority(a.status);
-      const statusPriorityB = getStatusPriority(b.status);
-      
-      if (statusPriorityA !== statusPriorityB) {
-        return statusPriorityA - statusPriorityB;
-      }
-      
-      const dateA = new Date(a.created_at || a.created_date || 0);
-      const dateB = new Date(b.created_at || b.created_date || 0);
-      return dateB - dateA;
-    });
-  };
-
   const loadData = async () => {
     try {
       setIsLoading(true);
@@ -195,16 +167,7 @@ const TransfersProvider = ({ children }) => {
         filter,
         sorting,
       });
-      let preparedRows = prepareRows(await data.transfers);
-
-      const isDefaultSort = 
-        sorting.sort_by === defaultSorting.sort_by && 
-        sorting.order === defaultSorting.order;
-      
-      if (isDefaultSort) {
-        preparedRows = sortRowsByDefaultOrder(preparedRows);
-      }
-
+      const preparedRows = prepareRows(await data.transfers);
       setTableRows(preparedRows);
       setTotalRowCount(data.total);
     } catch (error) {


### PR DESCRIPTION
### Summary
Cleans up the TransfersContext by removing redundant sorting logic that is now handled by the backend. This refactor simplifies the frontend code and improves maintainability

### Tasks Completed
- [x] Removed getStatusPriority function from TransfersContext
- [x] Removed sortRowsByDefaultOrder function from TransfersContext
- [x] Simplified data preparation flow by eliminating redundant default sorting checks
- [x] Enhanced code clarity by removing unused logic