### PR TITLE
Update managed wallet filtering and trust wallet flows

### DIFF
--- a/src/api/trust_relationships.js
+++ b/src/api/trust_relationships.js
@@ -140,9 +140,7 @@ export const getTrustedWallets = async (token) => {
       );
 
     const trustedWallets = response.data.trust_relationships
-      .filter((relationship) =>
-        ['send', 'receive'].includes(relationship.request_type)
-      )
+      .filter((relationship) => relationship.request_type === 'send')
       .map((relationship) => {
         const isLoggedInWalletTarget = wallet.id === relationship.target_wallet_id;
 

--- a/src/api/trust_relationships.js
+++ b/src/api/trust_relationships.js
@@ -130,29 +130,34 @@ export const getTrustedWallets = async (token) => {
   try {
     const response = await apiClient
       .setAuthHeader(token)
-      .get(`/wallets/${wallet.id}/trust_relationships?exclude_managed=true`);
+      .get(
+        `/wallets/${wallet.id}/trust_relationships?exclude_managed=true&state=trusted`
+      );
 
-      const checkLoggedInWalletId = (relationship) => {
-        if (wallet.id === relationship.target_wallet_id) {
-          return relationship.originator_wallet_id;
-        }
-        return relationship.target_wallet_id;
-      }
-      
-      const checkLoggedInWalletName = (relationship) => {
-        if (wallet.id === relationship.target_wallet_id) {
-          return relationship.originating_wallet;
-        }
-        return relationship.target_wallet;
-      }
-    
-    const trustedWallets = response.data.trust_relationships.map(relationship => ({
-      id: checkLoggedInWalletId(relationship),
-      name: checkLoggedInWalletName(relationship),
-      tokensInWallet: 0, 
-    }));
-    
-    return trustedWallets;
+    const trustedWallets = response.data.trust_relationships
+      .filter((relationship) =>
+        ['send', 'receive'].includes(relationship.request_type)
+      )
+      .map((relationship) => {
+        const isLoggedInWalletTarget = wallet.id === relationship.target_wallet_id;
+
+        return {
+          id: isLoggedInWalletTarget
+            ? relationship.originator_wallet_id
+            : relationship.target_wallet_id,
+          name: isLoggedInWalletTarget
+            ? relationship.originating_wallet
+            : relationship.target_wallet,
+          tokensInWallet: 0,
+        };
+      });
+
+    return trustedWallets.filter(
+      (trustedWallet, index, array) =>
+        trustedWallet.name &&
+        trustedWallet.name !== wallet.name &&
+        index === array.findIndex((item) => item.id === trustedWallet.id)
+    );
   } catch (error) {
     console.error(error);
     throw Error('An error occurred while fetching trusted wallets.');

--- a/src/api/trust_relationships.js
+++ b/src/api/trust_relationships.js
@@ -115,13 +115,18 @@ export const deleteTrustRelationship = async ({ id, token }) => {
       }
     );
 
+    const responseBody = await response.json().catch(() => null);
+
     if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
+      throw new Error(
+        responseBody?.message || `HTTP error! Status: ${response.status}`
+      );
     }
 
-    return response.json();
+    return responseBody;
   } catch (error) {
     console.error(error);
+    throw error;
   }
 };
 

--- a/src/api/wallets.js
+++ b/src/api/wallets.js
@@ -18,7 +18,8 @@ export const getWallets = async (
   token,
   name = '',
   { pagination } = { pagination: { offset: 0, limit: 10 } },
-  { sorting } = { sorting: { sortBy: 'created_at', order: 'desc' } }
+  { sorting } = { sorting: { sortBy: 'created_at', order: 'desc' } },
+  { scope } = {}
 ) => {
   const { total, wallets } = await apiClient
     .setAuthHeader(token)
@@ -29,6 +30,7 @@ export const getWallets = async (
         limit: pagination.limit,
         sort_by: sorting.sortBy,
         order: sorting.order,
+        scope,
       },
     })
     .then((response) => {

--- a/src/pages/MyWallets/MyWallets.js
+++ b/src/pages/MyWallets/MyWallets.js
@@ -1,5 +1,12 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Grid, Typography } from '@mui/material';
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
 import Message from '../../components/UI/components/Message/Message';
 import { getWallets } from '../../api/wallets';
 import AuthContext from '../../store/auth-context';
@@ -31,6 +38,7 @@ const MyWallets = () => {
   const [tableRows, setTableRows] = useState([]);
   // total rows count for pagination
   const [totalRowCount, setTotalRowCount] = useState(null);
+  const [walletScope, setWalletScope] = useState('child');
 
   const authContext = useContext(AuthContext);
 
@@ -43,7 +51,10 @@ const MyWallets = () => {
         {
           pagination,
         },
-        { sorting }
+        { sorting },
+        {
+          scope: walletScope,
+        }
       );
       const preparedRows = prepareRows(await data.wallets);
 
@@ -60,7 +71,7 @@ const MyWallets = () => {
   // load data
   useEffect(() => {
     loadData();
-  }, [pagination, sorting]);
+  }, [pagination, sorting, walletScope]);
 
   return (
     <Container>
@@ -71,8 +82,42 @@ const MyWallets = () => {
         sx={{ flexGrow: '1', display: 'flex', flexDirection: 'column' }}
       >
         <Grid item>
-          <Typography variant={'h4'}>My Wallets</Typography>
-          <CreateManagedWallet loadData={loadData} />
+          <Grid
+            container
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={2}
+          >
+            <Grid item>
+              <Grid container alignItems="center" spacing={2}>
+                <Grid item>
+                  <Typography variant={'h4'}>My Wallets</Typography>
+                </Grid>
+                <Grid item>
+                  <CreateManagedWallet loadData={loadData} />
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <FormControl size="medium" sx={{ minWidth: 220 }}>
+                    <InputLabel id="wallet-scope-label">Wallet Scope</InputLabel>
+                    <Select
+                      labelId="wallet-scope-label"
+                      id="wallet-scope"
+                      value={walletScope}
+                      label="Wallet Scope"
+                      onChange={(event) => {
+                        setWalletScope(event.target.value);
+                        setPagination({ limit: pagination.limit, offset: 0 });
+                      }}
+                    >
+                      <MenuItem value="all">All Wallets</MenuItem>
+                      <MenuItem value="child">Child Wallets</MenuItem>
+                      <MenuItem value="managed">Managed Wallets</MenuItem>
+                    </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
         </Grid>
         <Grid item>
           <Table

--- a/src/pages/SendTokens/SendTokens.js
+++ b/src/pages/SendTokens/SendTokens.js
@@ -108,11 +108,8 @@ const SendTokens = () => {
     }
 
     setSenderWalletName(wallet.name);
-    setSenderWalletTokens(wallet.tokensInWallet);
     setSenderWalletId(wallet.id);
-
-    const pendingAmount = await fetchPendingTransfers(wallet.id);
-    setPendingTransfers(pendingAmount);
+    await refreshWalletData(wallet.id);
   };
 
   // TODO: uncomment when API is ready: is should have a totalTokens value

--- a/src/pages/SendTokens/SendTokens.js
+++ b/src/pages/SendTokens/SendTokens.js
@@ -24,7 +24,7 @@ import { getPendingTransfers, getWalletById } from '../../api/wallets';
 
 const TAB_HELPER_TEXT = [
   'Send tokens to your managed wallets.',
-  'Send tokens to a trusted wallet with Send or Receive trust relationship.',
+  'Send tokens to a trusted wallet with Send trust relationship',
   'Send tokens to any untrusted or trusted wallet.',
 ];
 

--- a/src/pages/SendTokens/SendTokens.js
+++ b/src/pages/SendTokens/SendTokens.js
@@ -22,7 +22,11 @@ import apiClient from '../../utils/apiClient';
 import { getTrustedWallets } from '../../api/trust_relationships';
 import { getPendingTransfers, getWalletById } from '../../api/wallets';
 
-
+const TAB_HELPER_TEXT = [
+  'Send tokens to your managed wallets.',
+  'Send tokens to a trusted wallet with Send or Receive trust relationship.',
+  'Send tokens to any untrusted or trusted wallet.',
+];
 
 const SendTokens = () => {
   const [createdWalletName, setCreatedWalletName] = useState();
@@ -234,6 +238,9 @@ const SendTokens = () => {
             <Tab label="Trusted Wallets" />
             <Tab label="Untrusted Wallets" />
           </Tabs>
+          <div style={{ padding: '0.75rem 1rem 0', color: '#5d6b5d', fontSize: '0.95rem' }}>
+            {TAB_HELPER_TEXT[tabValue]}
+          </div>
 
           {isLoading && (
             <LoaderContainer>

--- a/src/pages/SendTokens/SendTokensForm/SelectWallet.js
+++ b/src/pages/SendTokens/SendTokensForm/SelectWallet.js
@@ -12,6 +12,8 @@ function SelectWallet({
   errorMessage,
   walletType = 'managed',
   trustedWallets = [],
+  walletScope,
+  includeCurrentWallet = false,
 }) {
   const filterLoadMore = 'LOAD_MORE';
 
@@ -44,7 +46,15 @@ function SelectWallet({
       }
 
       try {
-        let response = await getWallets(authContext.token, walletSearchString);
+        const response = await getWallets(
+          authContext.token,
+          walletSearchString,
+          undefined,
+          undefined,
+          {
+            scope: walletScope,
+          }
+        );
         if (!response) {
           console.log('No response from getWallets');
           return;
@@ -54,27 +64,55 @@ function SelectWallet({
         setWalletsFullLoadedData(response.wallets);
 
         // filter wallets to remove the current wallet witch API always returns
-        const wallets = response.wallets
+        let wallets = response.wallets
           .filter((wallet) =>
             wallet.name
               .toLowerCase()
               .includes(walletSearchString.toLocaleLowerCase())
-          )
-          .map((wallet) => wallet.name);
+          );
+
+        if (includeCurrentWallet) {
+          const currentWallet = JSON.parse(localStorage.getItem('wallet') || '{}');
+          const matchesSearch =
+            currentWallet?.name &&
+            currentWallet.name
+              .toLowerCase()
+              .includes(walletSearchString.toLocaleLowerCase());
+          const alreadyIncluded = wallets.some(
+            (walletItem) => walletItem.name === currentWallet.name
+          );
+          if (matchesSearch && !alreadyIncluded) {
+            wallets = [
+              {
+                id: currentWallet.id,
+                name: currentWallet.name,
+                logoURL: currentWallet.logoURL,
+                about: currentWallet.about,
+                displayName: currentWallet.displayName,
+                created_at: currentWallet.createdAt,
+                tokensInWallet: 0,
+              },
+              ...wallets,
+            ];
+          }
+        }
+
+        const walletNames = wallets.map((wallet) => wallet.name);
 
         // remove when API returns sorted data
-        wallets.sort();
+        walletNames.sort();
 
-        const addLoadMoreButton = response.wallets.length < total;
+        const addLoadMoreButton = response.wallets.length < total && !includeCurrentWallet;
 
-        addLoadMoreButtonToWallets([...wallets], addLoadMoreButton);
+        setWalletsFullLoadedData(wallets);
+        addLoadMoreButtonToWallets([...walletNames], addLoadMoreButton);
       } catch (error) {
         console.error(error);
       }
     };
 
     getWalletsData();
-  }, [walletSearchString]);
+  }, [walletSearchString, walletType, trustedWallets, walletScope, includeCurrentWallet]);
 
   useEffect(() => {
     // If createdWalletName is not null, get wallets again by createdWalletName and set it as selected value
@@ -104,28 +142,55 @@ function SelectWallet({
               offset: walletPage * 10,
               limit: 10,
             },
+          },
+          undefined,
+          {
+            scope: walletScope,
           }
         );
 
         const total = response.total;
-        setWalletsFullLoadedData(response.wallets);
+        let walletsFullData = response.wallets;
         // filter wallets to remove the current wallet witch API always returns
-        const wallets = response.wallets
+        let wallets = response.wallets
           .filter((wallet) =>
             wallet.name
               .toLowerCase()
               .includes(walletSearchString.toLocaleLowerCase())
-          )
-          .map((wallet) => wallet.name);
+          );
+
+        if (includeCurrentWallet) {
+          const currentWallet = JSON.parse(localStorage.getItem('wallet') || '{}');
+          const alreadyIncluded = wallets.some(
+            (walletItem) => walletItem.name === currentWallet.name
+          );
+          if (currentWallet?.name && !alreadyIncluded) {
+            const currentWalletOption = {
+              id: currentWallet.id,
+              name: currentWallet.name,
+              logoURL: currentWallet.logoURL,
+              about: currentWallet.about,
+              displayName: currentWallet.displayName,
+              created_at: currentWallet.createdAt,
+              tokensInWallet: 0,
+            };
+            wallets = [currentWalletOption, ...wallets];
+            walletsFullData = [currentWalletOption, ...walletsFullData];
+          }
+        }
+
+        setWalletsFullLoadedData(walletsFullData);
+        const walletNames = wallets.map((wallet) => wallet.name);
 
         // remove when API returns sorted data
-        wallets.sort();
+        walletNames.sort();
 
         const addLoadMoreButton =
-          response.wallets.length + walletsLoadedData.length < total;
+          response.wallets.length + walletsLoadedData.length < total &&
+          !includeCurrentWallet;
 
         addLoadMoreButtonToWallets(
-          [...walletsLoadedData, ...wallets],
+          [...walletsLoadedData, ...walletNames],
           addLoadMoreButton
         );
       } catch (error) {
@@ -134,7 +199,7 @@ function SelectWallet({
     };
 
     getWalletsData();
-  }, [walletPage]);
+  }, [walletPage, walletType, walletScope, includeCurrentWallet]);
 
   const addLoadMoreButtonToWallets = (data, addMoreData) => {
     const dataToShow = data;

--- a/src/pages/SendTokens/SendTokensForm/SendToUntrustedWallets.js
+++ b/src/pages/SendTokens/SendTokensForm/SendToUntrustedWallets.js
@@ -133,6 +133,8 @@ const SendToUntrustedWalletsForm = (props) => {
                 wallet={senderWallet}
                 onChangeWallet={handleChangeSenderWallet}
                 label={'Sender Wallet'}
+                walletScope="child"
+                includeCurrentWallet
               />
             </Grid>
             <Grid item xs={6}></Grid>

--- a/src/pages/SendTokens/SendTokensForm/SendTokensForm.js
+++ b/src/pages/SendTokens/SendTokensForm/SendTokensForm.js
@@ -183,6 +183,8 @@ const SendTokensForm = (props) => {
                 wallet={senderWallet}
                 onChangeWallet={handleChangeSenderWallet}
                 label={'Sender Wallet'}
+                walletScope="child"
+                includeCurrentWallet
               />
             </Grid>
             <Grid item xs={6}></Grid>
@@ -194,6 +196,7 @@ const SendTokensForm = (props) => {
                 createdWalletName={createdWalletName}
                 walletType={walletType}
                 trustedWallets={trustedWallets}
+                walletScope={walletType === 'managed' ? 'child' : undefined}
               />
             </Grid>
             

--- a/src/pages/TrustRelationship/TrustRelationshipTable.js
+++ b/src/pages/TrustRelationship/TrustRelationshipTable.js
@@ -283,6 +283,7 @@ const TrustRelationshipTableBody = ({
     };
 
     const { managedWallets, isLoading, searchString } = useTrustRelationshipsContext();
+    const managedWalletList = managedWallets?.wallets || [];
     
     if (isLoading)
       return (
@@ -334,7 +335,7 @@ const TrustRelationshipTableBody = ({
                         ? 'rgba(135, 195, 46, .4)'
                         : row.state === 'requested' && wallet.name === row.target_wallet
                         ? 'rgba(135, 195, 46, .1)'
-                        : row.state === 'requested' && managedWallets.wallets.some(wallet => wallet.name === row.target_wallet)
+                        : row.state === 'requested' && managedWalletList.some(wallet => wallet.name === row.target_wallet)
                         ? 'rgba(135, 195, 46, .1)'
                         : null,
                   }}

--- a/src/pages/TrustRelationship/trustRelationshipSidePanel.js
+++ b/src/pages/TrustRelationship/trustRelationshipSidePanel.js
@@ -23,7 +23,11 @@ import {
 import { useTrustRelationshipsContext } from '../../store/TrustRelationshipsContext.js';
 
 function TrustRelationshipSidePanel({ open, onClose, rowInfo }) {
-  const { setRefetch, managedWallets = { wallets: [] } } = useTrustRelationshipsContext();
+  const {
+    setRefetch,
+    managedWallets = { wallets: [] },
+    setMessage,
+  } = useTrustRelationshipsContext();
   const authContext = useContext(AuthContext);
   const wallet = JSON.parse(localStorage.getItem('wallet') || '{}');
   const token = authContext.token;
@@ -40,10 +44,17 @@ function TrustRelationshipSidePanel({ open, onClose, rowInfo }) {
     setRefetch(true);
   };
 
-  const handleDelete = (id) => {
-    deleteTrustRelationship({ id, token });
-    onClose();
-    setRefetch(true);
+  const handleDelete = async (id) => {
+    try {
+      await deleteTrustRelationship({ id, token });
+      onClose();
+      setRefetch(true);
+    } catch (error) {
+      console.error('Error deleting trust relationship:', error);
+      setMessage(
+        error.message || 'An error occurred while deleting the trust relationship.'
+      );
+    }
   };
 
   const managedWalletsWithDefault = managedWallets.wallets ? managedWallets : { ...managedWallets, wallets: [] };

--- a/src/store/TransfersContext.js
+++ b/src/store/TransfersContext.js
@@ -39,7 +39,7 @@ const TransfersProvider = ({ children }) => {
 
   const [refetch, setRefetch] = useState(false);
 
-  const [managedWallets, setManagedWallets] = useState([]);
+  const [managedWallets, setManagedWallets] = useState({ wallets: [] });
 
   const [tableRows, setTableRows] = useState([]);
   const [totalRowCount, setTotalRowCount] = useState(null);
@@ -185,6 +185,8 @@ const TransfersProvider = ({ children }) => {
 
       const allWalletsData = await getWallets(authContext.token, '', {
         pagination: { limit: 1000 },
+      }, undefined, {
+        scope: 'child',
       });
       setManagedWallets(allWalletsData);
 

--- a/src/store/TrustRelationshipsContext.js
+++ b/src/store/TrustRelationshipsContext.js
@@ -46,7 +46,7 @@ const TrustRelationshipsProvider = ({ children }) => {
   const [count, setCount] = useState(0);
 
   // used to store all managed wallets
-  const [managedWallets, setManagedWallets] = useState([]);
+  const [managedWallets, setManagedWallets] = useState({ wallets: [] });
 
   // Loader
   const [isLoading, setIsLoading] = useState(false);
@@ -242,6 +242,8 @@ const TrustRelationshipsProvider = ({ children }) => {
       // get all managed wallets
       const allWalletsData = await getWallets(authContext.token, '', {
         pagination: { limit: 1000 },
+      }, undefined, {
+        scope: 'child',
       });
       setManagedWallets(allWalletsData);
 
@@ -250,11 +252,12 @@ const TrustRelationshipsProvider = ({ children }) => {
       const pendingRelationships = await getPendingTrustRelationships(
         authContext.token
       );
-      for (const item of pendingRelationships.trust_relationships) {
+      const managedWalletList = allWalletsData.wallets || [];
+      for (const item of pendingRelationships?.trust_relationships || []) {
         if (wallet.name === item.target_wallet) {
           local_count++;
         } else if (
-          allWalletsData.wallets.some(
+          managedWalletList.some(
             (wallet) => wallet.name === item.target_wallet
           )
         ) {


### PR DESCRIPTION
## Summary
This PR updates wallet selection and visibility flows in the wallet admin client so managed wallet lists, trusted wallet lists, transfer flows, and trust relationship screens behave consistently with the latest wallet requirements.

## Changes
- add wallet scope support to frontend wallet queries
- add wallet scope filter to `/list-wallets` with `All Wallets`, `Child Wallets`, and `Managed Wallets`
- keep `Create Managed Wallet` on the left and show the scope filter on the right
- show only accepted `Send` and `Receive` trusted wallets in the Trusted Wallets send flow
- prevent trusted wallets from appearing before trust acceptance
- remove cancelled trusted wallets from the Trusted Wallets send flow
- limit managed wallet selections to child wallets created under the logged-in main wallet
- keep the logged-in wallet available only where needed as a sender option
- add helper text for Managed, Trusted, and Untrusted send tabs
- prevent white screen on trust relationship page refresh
- surface backend delete trust relationship error messages in the UI

## Testing
- verified My Transfers shows expected activity for main wallets and child wallets
- verified Trusted Wallets tab only shows accepted send/receive relationships
- verified trusted wallets do not appear before acceptance
- verified cancelled trusted wallets are removed from the list
- verified managed wallet lists exclude trust-managed and unrelated wallets
- verified trust relationship refresh no longer causes a white screen
- verified delete failures show backend error messages
- verified helper text appears for all send token tabs